### PR TITLE
Fix autoimport/intellisense

### DIFF
--- a/template/javascript/base/jsconfig.json
+++ b/template/javascript/base/jsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "module": "esnext",
     "baseUrl": "./",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "paths": {
       "@/*": [
         "src/*"


### PR DESCRIPTION
for example I couldn't let vs code auto import `ref` from 'vue' when i simply write ref (TS error) this fixes it