### PR TITLE
fix: specify type for vue-router routes

### DIFF
--- a/template/typescript/base/src/router/index.ts
+++ b/template/typescript/base/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes: RouteRecordRaw = [
+const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),

--- a/template/typescript/base/src/router/index.ts
+++ b/template/typescript/base/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes = [
+const routes: RouteRecordRaw = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),

--- a/template/typescript/custom/router/src/router/index.ts
+++ b/template/typescript/custom/router/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes: RouteRecordRaw = [
+const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),

--- a/template/typescript/custom/router/src/router/index.ts
+++ b/template/typescript/custom/router/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes = [
+const routes: RouteRecordRaw = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),

--- a/template/typescript/essentials/src/router/index.ts
+++ b/template/typescript/essentials/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes: RouteRecordRaw = [
+const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),

--- a/template/typescript/essentials/src/router/index.ts
+++ b/template/typescript/essentials/src/router/index.ts
@@ -1,7 +1,7 @@
 // Composables
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-const routes = [
+const routes: RouteRecordRaw = [
   {
     path: '/',
     component: () => import('@/layouts/default/Default.vue'),


### PR DESCRIPTION
Doing so will avoid this cryptic error when using named routes https://github.com/vuejs/router/issues/1213

Hopefully this will help reduce possible sources of friction when trying out a new vuetify project, like I encountered today.