### PR TITLE
fix: content not centered

### DIFF
--- a/template/javascript/base/src/components/HelloWorld.vue
+++ b/template/javascript/base/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>

--- a/template/javascript/default/src/components/HelloWorld.vue
+++ b/template/javascript/default/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>

--- a/template/javascript/essentials/src/components/HelloWorld.vue
+++ b/template/javascript/essentials/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>

--- a/template/typescript/base/src/components/HelloWorld.vue
+++ b/template/typescript/base/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>

--- a/template/typescript/default/src/components/HelloWorld.vue
+++ b/template/typescript/default/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>

--- a/template/typescript/essentials/src/components/HelloWorld.vue
+++ b/template/typescript/essentials/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="fill-height">
-    <v-responsive class="d-flex align-center text-center fill-height">
+    <v-responsive class="align-center text-center fill-height">
       <v-img height="300" src="@/assets/logo.svg" />
 
       <div class="text-body-2 font-weight-light mb-n1">Welcome to</div>


### PR DESCRIPTION
Content is off center because `d-flex` class overrides `display: grid` on `v-responsive`

![image](https://github.com/vuetifyjs/create-vuetify/assets/623137/c5f8f34c-8d61-4522-87c9-4c3169f84843)
