### PR TITLE
fix: import plugins before components

### DIFF
--- a/template/javascript/base/src/main.js
+++ b/template/javascript/base/src/main.js
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 

--- a/template/javascript/default/src/main.js
+++ b/template/javascript/default/src/main.js
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 

--- a/template/javascript/essentials/src/main.js
+++ b/template/javascript/essentials/src/main.js
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 

--- a/template/typescript/base/src/main.ts
+++ b/template/typescript/base/src/main.ts
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 

--- a/template/typescript/default/src/main.ts
+++ b/template/typescript/default/src/main.ts
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 

--- a/template/typescript/essentials/src/main.ts
+++ b/template/typescript/essentials/src/main.ts
@@ -4,14 +4,14 @@
  * Bootstraps Vuetify and other plugins then mounts the App`
  */
 
+// Plugins
+import { registerPlugins } from '@/plugins'
+
 // Components
 import App from './App.vue'
 
 // Composables
 import { createApp } from 'vue'
-
-// Plugins
-import { registerPlugins } from '@/plugins'
 
 const app = createApp(App)
 


### PR DESCRIPTION
The import order in main.js/main.ts was wrong according to this issue:
[[Bug Report][3.3.8] VBtn color incorrect](https://github.com/vuetifyjs/vuetify/issues/17796#issuecomment-1639479130)