### PR TITLE
feat: support bun package manager

### DIFF
--- a/src/utils/installDependencies.ts
+++ b/src/utils/installDependencies.ts
@@ -1,11 +1,13 @@
 import { spawnSync } from 'child_process'
 
-function installDependencies(projectRoot: string, packageManager: 'npm' | 'yarn' | 'pnpm') {
+function installDependencies(projectRoot: string, packageManager: 'npm' | 'yarn' | 'pnpm' | 'bun') {
   const cmd = (
     packageManager === 'npm' ?
       'npm install' :
       packageManager === 'yarn' ?
-        'yarn' :
+        'yarn' : 
+      packageManager === 'bun' ?
+        'bun install' :
         'pnpm install'
   )
   

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -17,7 +17,7 @@ type ContextState = {
   canOverwrite?: boolean,
   useEslint?: boolean,
   useTypeScript?: boolean,
-  usePackageManager?: 'npm' | 'pnpm' | 'yarn',
+  usePackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun',
   usePreset?: 'base' | 'default' | 'essentials' | 'custom',
   useStore?: 'vuex' | 'pinia' | boolean,
   useRouter?: boolean,
@@ -98,12 +98,13 @@ const promptQuestions = (context: ContextState): PromptObject<string>[] => [
   {
     name: 'usePackageManager',
     type: 'select',
-    message: 'Would you like to install dependencies with yarn, npm, or pnpm?',
+    message: 'Would you like to install dependencies with yarn, npm, pnpm, or bun?',
     initial: 0,
     choices: [
       { title: 'yarn', value: 'yarn' },
       { title: 'npm', value: 'npm' },
       { title: 'pnpm', value: 'pnpm' },
+      { title: 'bun', value: 'bun' },
       { title: 'none', value: null },
     ],
   },

--- a/template/javascript/base/README.md
+++ b/template/javascript/base/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# pnpm
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun
+bun run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun
+bun run build
 ```
 
 ### Lints and fixes files
@@ -50,6 +59,9 @@ npm run lint
 
 # pnpm
 pnpm lint
+
+# bun
+bun run lint
 ```
 
 ### Customize configuration

--- a/template/javascript/default/README.md
+++ b/template/javascript/default/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# bun
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun
+bun run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun
+bun run build
 ```
 
 ### Customize configuration

--- a/template/javascript/essentials/README.md
+++ b/template/javascript/essentials/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# bun
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun
+bun run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun
+bun run build
 ```
 
 ### Lints and fixes files
@@ -50,6 +59,9 @@ npm run lint
 
 # pnpm
 pnpm lint
+
+# bun
+bun run lint
 ```
 
 ### Customize configuration

--- a/template/typescript/base/README.md
+++ b/template/typescript/base/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# bun
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun
+pnpm run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun
+pnpm run build
 ```
 
 ### Lints and fixes files
@@ -50,6 +59,9 @@ npm run lint
 
 # pnpm
 pnpm lint
+
+# bun
+pnpm run lint
 ```
 
 ### Customize configuration

--- a/template/typescript/default/README.md
+++ b/template/typescript/default/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# bun
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun
+bun run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun
+bun run build
 ```
 
 ### Customize configuration

--- a/template/typescript/essentials/README.md
+++ b/template/typescript/essentials/README.md
@@ -11,6 +11,9 @@ npm install
 
 # pnpm
 pnpm install
+
+# bun 
+bun install
 ```
 
 ### Compiles and hot-reloads for development
@@ -24,6 +27,9 @@ npm run dev
 
 # pnpm
 pnpm dev
+
+# bun 
+bun run dev
 ```
 
 ### Compiles and minifies for production
@@ -37,6 +43,9 @@ npm run build
 
 # pnpm
 pnpm build
+
+# bun 
+bun run build
 ```
 
 ### Lints and fixes files
@@ -50,6 +59,9 @@ npm run lint
 
 # pnpm
 pnpm lint
+
+# bun 
+bun run lint
 ```
 
 ### Customize configuration


### PR DESCRIPTION
Adds `bun` as a package manager option in `create-vuetify`

[bun.sh/package-manager](https://bun.sh/package-manager)

Here's a successful run on my local machine:

```sh
$ node dist/output.cjs 

Vuetify.js - Material Component Framework for Vue

✔ Project name: … asdfasdf
✔ Which preset would you like to install? › Default (Vuetify)
✔ Use TypeScript? … No / Yes
✔ Would you like to install dependencies with yarn, npm, pnpm, or bun? › bun

◌ Generating scaffold...
◌ Installing dependencies with bun...

 + @babel/types@7.22.10
 + @types/node@18.17.8
 + @vitejs/plugin-vue@4.3.3
 + typescript@5.1.6
 + unplugin-fonts@1.0.3
 + vite@4.4.9
 + vite-plugin-vuetify@1.0.2
 + vue-tsc@1.8.8
 + @mdi/font@7.0.96
 + roboto-fontface@0.10.0
 + vue@3.3.4
 + vuetify@3.3.14

 96 packages installed [1239.00ms]

asdfasdf has been generated at /Users/colinmcd94/Documents/repos/create-vuetify/asdfasdf

Discord community: https://community.vuetifyjs.com
Github: https://github.com/vuetifyjs/vuetify
Support Vuetify: https://github.com/sponsors/johnleider
```