### PR TITLE
feat(typescript): add tsx file support and unplugin vue router type declare

### DIFF
--- a/template/typescript/default/package.json
+++ b/template/typescript/default/package.json
@@ -15,6 +15,8 @@
     "@babel/types": "^7.23.0",
     "@types/node": "^20.10.0",
     "@vitejs/plugin-vue": "^4.5.0",
+    "@vitejs/plugin-vue-jsx": "^3.1.0",
+    "@vue/tsconfig": "^0.5.1",
     "sass": "^1.69.0",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",

--- a/template/typescript/default/vite.config.mts
+++ b/template/typescript/default/vite.config.mts
@@ -1,6 +1,7 @@
 // Plugins
 import Components from 'unplugin-vue-components/vite'
 import Vue from '@vitejs/plugin-vue'
+import VueJsx from '@vitejs/plugin-vue-jsx'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 import ViteFonts from 'unplugin-fonts/vite'
 
@@ -14,6 +15,7 @@ export default defineConfig({
     Vue({
       template: { transformAssetUrls },
     }),
+    VueJsx(),
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme
     Vuetify(),
     Components(),

--- a/template/typescript/essentials/src/HelloWorldTSX.tsx
+++ b/template/typescript/essentials/src/HelloWorldTSX.tsx
@@ -1,0 +1,22 @@
+import { defineComponent, ref } from 'vue'
+import { VTextField } from 'vuetify/components'
+import { withEventModifiers } from './directives'
+
+export const HelloWorldTSX = defineComponent({
+    name: 'HelloWorld',
+    setup() {
+        const text = ref('')
+        
+        return () => (
+            <VTextField
+                v-model={text.value}
+                {...withEventModifiers({
+                    onKeyup: () => {
+                        console.log('enter event');
+                    } 
+                  }, ['enter']
+                )} 
+            />
+        )
+    }
+})

--- a/template/typescript/essentials/src/directives/index.ts
+++ b/template/typescript/essentials/src/directives/index.ts
@@ -1,0 +1,1 @@
+export * from './withEventModifiers'

--- a/template/typescript/essentials/src/directives/withEventModifiers.ts
+++ b/template/typescript/essentials/src/directives/withEventModifiers.ts
@@ -1,0 +1,114 @@
+// # https://github.com/vuejs/babel-plugin-jsx/issues/596
+import { withModifiers, withKeys, capitalize } from 'vue';
+import { makeMap } from '@vue/shared';
+
+const isEventOptionModifier = makeMap(`passive,once,capture`);
+const isNonKeyModifier = makeMap(
+  // event propagation management
+  `stop,prevent,self,` +
+  // system modifiers + exact
+  `ctrl,shift,alt,meta,exact,` +
+  // mouse
+  `middle`
+);
+// left & right could be mouse or key modifiers based on event type
+const maybeKeyModifier = makeMap('left,right');
+const isKeyboardEvent = makeMap(
+  `onkeyup,onkeydown,onkeypress`,
+  true,
+);
+
+export const resolveEventModifiers = ({
+  eventName,
+  eventModifiers,
+}: {
+  eventName: string;
+  eventModifiers: string[];
+}) => {
+  const keyModifiers: string[] = [];
+  const nonKeyModifiers: string[] = [];
+  const eventOptionModifiers: string[] = [];
+
+  for (let i = 0; i < eventModifiers.length; i++) {
+    const eventModifier = eventModifiers[i];
+
+    if (isEventOptionModifier(eventModifier)) {
+      // eventOptionModifiers: modifiers for addEventListener() options,
+      // e.g. .passive & .capture
+      eventOptionModifiers.push(eventModifier)
+    } else {
+      // runtimeModifiers: modifiers that needs runtime guards
+      if (maybeKeyModifier(eventModifier)) {
+        if (isKeyboardEvent(eventName)) {
+          keyModifiers.push(eventModifier);
+        } else {
+          nonKeyModifiers.push(eventModifier);
+        }
+      } else {
+        if (isNonKeyModifier(eventModifier)) {
+          nonKeyModifiers.push(eventModifier);
+        } else {
+          keyModifiers.push(eventModifier);
+        }
+      }
+    }
+  }
+
+  return {
+    keyModifiers,
+    nonKeyModifiers,
+    eventOptionModifiers,
+  };
+};
+
+export const withEventModifiers = (eventObject: object, modifiers: string[]) => {
+  const eventName: string = Object.keys(eventObject)[0];
+  const eventFunction: Function = Object.values(eventObject)[0];
+
+  const {
+    eventOptionModifiers,
+    keyModifiers,
+    nonKeyModifiers
+  } = resolveEventModifiers({
+    eventName,
+    eventModifiers: modifiers
+  });
+
+  let outputEventName = eventName;
+  let outputEventFunction = eventFunction;
+
+  // normalize click.right and click.middle since they don't actually fire
+  if (nonKeyModifiers.includes('right')) {
+    outputEventName = 'onContextmenu';
+  }
+
+  if (nonKeyModifiers.includes('middle')) {
+    outputEventName = 'onMouseup';
+  }
+
+
+  if (nonKeyModifiers.length > 0) {
+    // @ts-ignore
+    outputEventFunction = withModifiers(outputEventFunction, nonKeyModifiers);
+  }
+
+  if (
+    keyModifiers.length > 0 &&
+    // if event name is dynamic, always wrap with keys guard
+    isKeyboardEvent(eventName)
+  ) {
+    // @ts-ignore
+    outputEventFunction = withKeys(outputEventFunction, keyModifiers);
+  }
+
+  if (eventOptionModifiers.length > 0) {
+    const modifierPostfix = eventOptionModifiers.map(capitalize).join('');
+    outputEventName = `${outputEventName}${modifierPostfix}`;
+  }
+
+  const outputEventObject = {
+    [outputEventName]: outputEventFunction,
+  };
+
+  return outputEventObject;
+};

--- a/template/typescript/essentials/tsconfig.json
+++ b/template/typescript/essentials/tsconfig.json
@@ -20,7 +20,7 @@
       ]
      }
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "./typed-router.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }],
   "exclude": ["node_modules"]
 }

--- a/template/typescript/essentials/tsconfig.json
+++ b/template/typescript/essentials/tsconfig.json
@@ -18,7 +18,10 @@
       "@/*": [
        "src/*"
       ]
-     }
+     },
+		"types": [
+			"vite-plugin-vue-layouts/client"	
+		]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "./typed-router.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }],

--- a/template/typescript/essentials/tsconfig.node.json
+++ b/template/typescript/essentials/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+  },
+  "include": ["vite.config.mts"]
+}

--- a/template/typescript/essentials/vite.config.mts
+++ b/template/typescript/essentials/vite.config.mts
@@ -4,6 +4,7 @@ import Components from 'unplugin-vue-components/vite'
 import Fonts from 'unplugin-fonts/vite'
 import Layouts from 'vite-plugin-vue-layouts'
 import Vue from '@vitejs/plugin-vue'
+import VueJsx from '@vitejs/plugin-vue-jsx'
 import VueRouter from 'unplugin-vue-router/vite'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
@@ -14,11 +15,15 @@ import { fileURLToPath, URL } from 'node:url'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    VueRouter(),
+    // https://uvr.esm.is/guide/configuration.html#configuration
+    VueRouter({
+      extensions: ['.vue', '.tsx']
+    }),
     Layouts(),
     Vue({
       template: { transformAssetUrls },
     }),
+    VueJsx(),
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme
     Vuetify({
       autoImport: true,


### PR DESCRIPTION
- Use the new `tsconfig.json` and `tsconfig.node.json` files for the `essentials` template to ensure the support for type declare built by `unplugin-vue-router`. [docs](https://uvr.esm.is/introduction.html)
- Use `@vitejs/plugin-vue-jsx`, `@vue/tsconfig` and set `extension` option for VueRouter in `vite.config.mts` to fully support TSX files.