### PR TITLE
fix: vue-router not working when settings `base` option in vite.config

### DIFF
--- a/template/javascript/base/src/router/index.js
+++ b/template/javascript/base/src/router/index.js
@@ -9,7 +9,7 @@
 import { createRouter, createWebHistory } from 'vue-router/auto'
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
 })
 
 export default router

--- a/template/javascript/essentials/src/router/index.js
+++ b/template/javascript/essentials/src/router/index.js
@@ -9,7 +9,7 @@ import { createRouter, createWebHistory } from 'vue-router/auto'
 import { setupLayouts } from 'virtual:generated-layouts'
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   extendRoutes: setupLayouts,
 })
 

--- a/template/typescript/base/src/router/index.ts
+++ b/template/typescript/base/src/router/index.ts
@@ -8,7 +8,7 @@
 import { createRouter, createWebHistory } from 'vue-router/auto'
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
 })
 
 export default router

--- a/template/typescript/essentials/src/router/index.ts
+++ b/template/typescript/essentials/src/router/index.ts
@@ -9,7 +9,7 @@ import { createRouter, createWebHistory } from 'vue-router/auto'
 import { setupLayouts } from 'virtual:generated-layouts'
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   extendRoutes: setupLayouts,
 })
 


### PR DESCRIPTION
fix vue-router not working when settings `base` option in vite.config.*